### PR TITLE
Fix: Ensure application does not run into issues with 'typings'

### DIFF
--- a/ComdirectConnection.py
+++ b/ComdirectConnection.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Union, Dict as dict, List as list, Any
 import requests
 import json
 import secrets
@@ -25,7 +25,7 @@ class XOnceAuthenticationInfo:
 
 class DocumentMeta:
     archived: bool
-    dateRead: datetime | None
+    dateRead: Union[datetime, None]
     alreadyRead: bool
     predocumentExists: bool
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import json
 from ComdirectConnection import Connection, Document, XOnceAuthenticationInfo
 from settings import Settings
 from pathvalidate._filename import sanitize_filename
-from typing import Any
+from typing import Union, List as list, Dict as dict, Any 
 from enum import Enum
 from rich.console import Console
 from rich.table import Table
@@ -26,7 +26,7 @@ class IntPromptDeutsch(IntPrompt):
     illegal_choice_message = "[prompt.invalid.choice]Bitte eine der gültigen Optionen auswählen"
 
 
-def print(string: Any, highlight : bool| None= None):
+def print(string: Any, highlight : Union[bool, None]= None):
     console.print(string, highlight=highlight)
 
 


### PR DESCRIPTION
### Fix: Ensure application does not run into issues with 'typings'

**Description**

Hello! I tried to use your application to download files from my Comdirect Account. I ran into some issue that I fixed with the changes of this PR. I was then able to successfully download all the files and wanted to return the favor a little bit. Hope this helps and thanks very much!

**What was the problem?**
* `python main.py` was failing to launch due to typings not being imported or used.

**What did you do to fix it?**
* I have updated `main.py` and `ComdirectConnection.py` to get the application to launch into the scripted menu.
* Specifically, I have added imports for the typings `List`, `Dict` and `Union` and replaced generic variables definitions of multiple types, i.e. `datetime | None`, with Union, i.e. `Union[datetime, None]`

 **Why is this change necessary/beneficial?**
* The app would not run otherwise.

**Notes**
* Apple Mac Mini with a silicone chip, M2 Pro
* Python 3.8.20
* Followed the Readme exactly to get it running

**Screenshots**
These are screenshots of the errors that occurred before applying the changes.
![image](https://github.com/user-attachments/assets/9a03c65d-45c9-47ae-a213-aa58b2f9c7fa)
And then after that error was solved by importing "List as list" from typings, this error came:
![image](https://github.com/user-attachments/assets/251b88a7-a844-4f1b-b84e-f347a1c55933)
And so on.