### PR TITLE
Handle HTTP 500 errors gracefully during document download

### DIFF
--- a/ComdirectConnection.py
+++ b/ComdirectConnection.py
@@ -299,5 +299,10 @@ class Connection:
                 ),
             },
         )
-        r.raise_for_status()
-        return r.content
+        try:
+            r.raise_for_status()
+            return r.content
+        except requests.exceptions.HTTPError as e:
+            # Return None on HTTP errors (including 500) to allow the process to continue
+            print(f"HTTP Error {r.status_code} for document {document.documentId}: {str(e)}")
+            return None

--- a/main.py
+++ b/main.py
@@ -354,6 +354,10 @@ class Main:
                             # print("New filepath" + filepath)
                             if os.path.exists(filepath): # If there's multiple per same day, we append a counter
                                 docContent = self.conn.downloadDocument(document) # Gotta load early to check if content is same
+                                if docContent is None:
+                                    __printStatus(idx, document, "FEHLER - Download fehlgeschlagen (siehe oben)")
+                                    countSkipped += 1
+                                    continue
                                 if __isFileEqual(filepath, docContent):
                                     __printStatus(idx, document, "ÜBERSPRUNGEN - Datei bereits heruntergeladen")
                                     countSkipped += 1
@@ -383,6 +387,10 @@ class Main:
                         continue
                 if not docContent: # Ensure data is loaded
                     docContent = self.conn.downloadDocument(document)
+                if docContent is None:
+                    __printStatus(idx, document, "FEHLER - Download fehlgeschlagen (siehe oben)")
+                    countSkipped += 1
+                    continue
                 with open(filepath, "wb") as f:
                     f.write(docContent)
                     # shutil.copyfileobj(docContent, f)


### PR DESCRIPTION
* Catch HTTPError exceptions in downloadDocument and return None
* Continue processing remaining documents when download fails
* Display error message instead of crashing the entire process

For some old document, comdirect is throwing a 500, and the tool does not deal gracefully with that. This improves the situation imho, see https://github.com/senshi-x/ComdirectPostboxDownloader/issues/36